### PR TITLE
Links moved to .links file

### DIFF
--- a/src/bin/gen_deb_repository.rs
+++ b/src/bin/gen_deb_repository.rs
@@ -30,6 +30,7 @@ pub struct Source {
 static FILE_GENERATORS: &[(&str, fn(&PackageInstance, LazyCreateBuilder) -> io::Result<()>)] = &[
     ("config", crate::generator::config::generate),
     ("install", crate::generator::install::generate),
+    ("links", crate::generator::links::generate),
     ("postinst", crate::generator::postinst::generate),
     ("postrm", crate::generator::postrm::generate),
     ("templates", crate::generator::templates::generate),

--- a/src/bin/generator/links.rs
+++ b/src/bin/generator/links.rs
@@ -8,9 +8,7 @@ pub fn generate(instance: &PackageInstance, out: LazyCreateBuilder) -> io::Resul
         if let ConfType::Static { internal, .. } = &conf.conf_type {
             let dir = file_name.rfind('/').map(|pos| &file_name[..pos+1]).unwrap_or("");
             if *internal {
-                writeln!(out, "{}/usr/share/{}/internal_config/{} /usr/share/{}/internal_config/{}", instance.name, instance.internal_config_sub_dir(), file_name, instance.internal_config_sub_dir(), dir)?;
-            } else {
-                writeln!(out, "{}/etc/{}/{} /etc/{}/{}", instance.name, instance.config_sub_dir(), file_name, instance.config_sub_dir(), dir)?;
+                writeln!(out, "/usr/share/{}/internal_config/{} /etc/{}/{}", instance.internal_config_sub_dir(), file_name, instance.internal_config_sub_dir(), file_name)?;
             }
         }
     }

--- a/src/bin/generator/mod.rs
+++ b/src/bin/generator/mod.rs
@@ -6,4 +6,5 @@ pub mod service;
 pub mod templates;
 pub mod triggers;
 pub mod install;
+pub mod links;
 pub mod static_files;

--- a/src/bin/generator/static_files.rs
+++ b/src/bin/generator/static_files.rs
@@ -22,16 +22,6 @@ pub fn generate(instance: &PackageInstance, source_root: &Path) -> io::Result<()
 
             let mut file = fs::File::create(file_path)?;
             file.write_all(content.as_bytes())?;
-
-            if *internal {
-                let config_file_path = config_dir.join(file_name);
-                fs::create_dir_all(config_file_path.parent().expect("file_path doesn't have a parent"))?;
-                let mut share_relative = std::path::PathBuf::from("../../usr/share");
-                share_relative.push(&*instance.internal_config_sub_dir());
-                share_relative.push("internal_config");
-                share_relative.push(file_name);
-                std::os::unix::fs::symlink(share_relative, config_file_path)?;
-            }
         }
     }
 


### PR DESCRIPTION
This fixes the issue of having to run rm -rf build/*/*/etc
between builds.