### PR TITLE
Fix libcap-ng is too old for 'all' caps

### DIFF
--- a/src/bin/codegen/bash.rs
+++ b/src/bin/codegen/bash.rs
@@ -117,7 +117,9 @@ impl<'a, I> SecureCommand<'a, I> where I: IntoIterator, I::Item: fmt::Display {
             } else {
                 "--reset-env "
             };
-            write!(cmd_writer, "setpriv --reuid={} --regid={} --init-groups --inh-caps=-all {}{}-- ", self.user, self.group, no_new_privs, reset_env)?;
+            // Solution for setpriv: libcap-ng is too old for "all" caps
+            // https://github.com/SinusBot/docker/pull/40
+            write!(cmd_writer, "setpriv --reuid={} --regid={} --init-groups --inh-caps=-cap_$(seq -s ,-cap_ 0 $(cat /proc/sys/kernel/cap_last_cap)) {}{}-- ", self.user, self.group, no_new_privs, reset_env)?;
         }
         write!(cmd_writer, "{}", DisplayEscaped(self.program))?;
         for arg in self.args {


### PR DESCRIPTION
Refer to https://github.com/SinusBot/docker/pull/40

Now I know why [this](https://github.com/debian-cryptoanarchy/cryptoanarchy-deb-repo-builder/pull/200#issuecomment-1082828541) fails for GitHub Actions.

![image](https://user-images.githubusercontent.com/43995067/169517341-48f50f50-eb55-407e-aede-0a22e806724e.png)

Signed-off-by: Hollow Man <hollowman@opensuse.org>