### PR TITLE
Force linked-hash-map version to be 0.5.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ void = "1"
 itertools = "0.9"
 thiserror = "1.0.22"
 either = "1.6.1"
-linked-hash-map = { version = "0.5.3", features = ["serde_impl"] }
+linked-hash-map = { version = "= 0.5.4", features = ["serde_impl"] }
 fmt2io = "0.2.0"
 rfc822-like = "0.2.0"
 


### PR DESCRIPTION
Fix building issue here: https://github.com/HollowMan6/build-cryptoanarchy-deb-repo-builder/runs/7144776329?check_suite_focus=true

Referring to: https://stackoverflow.com/a/45224646/14343335

Signed-off-by: Hollow Man <hollowman@opensuse.org>