### PR TITLE
Allow specifying minimum database version

### DIFF
--- a/src/im_repr/mod.rs
+++ b/src/im_repr/mod.rs
@@ -961,6 +961,7 @@ impl TryFrom<crate::input::Migration> for Migration {
 
 pub struct DbConfig {
     pub template: String,
+    pub min_version: Option<String>,
     pub config_file_owner: Option<String>,
     pub config_file_group: Option<String>,
 }
@@ -975,6 +976,7 @@ impl TryFrom<crate::input::DbConfig> for DbConfig {
         require_fields!(value, template);
         Ok(DbConfig {
             template,
+            min_version: value.min_version,
             config_file_owner: value.config_file_owner,
             config_file_group: value.config_file_group,
         })

--- a/src/input.rs
+++ b/src/input.rs
@@ -267,6 +267,7 @@ pub(crate) struct DbConfig {
     pub(crate) span,
 
     pub(crate) template: String,
+    pub(crate) min_version: String,
     pub(crate) config_file_owner: String,
     pub(crate) config_file_group: String,
 }


### PR DESCRIPTION
Some applications may require a minimum version of database. This change adds the option to specify it.