### PR TITLE
Call dbc maintainer scripts from other scripts

### DIFF
--- a/src/bin/generator/postrm.rs
+++ b/src/bin/generator/postrm.rs
@@ -1,64 +1,82 @@
 use std::io::{self, Write};
 use debcrafter::im_repr::{PackageInstance, PackageConfig, ConfType, PackageOps, GeneratedType};
 use debcrafter::Set;
-use crate::codegen::{LazyCreateBuilder};
+use crate::codegen::{LazyCreateBuilder, LazyWriter};
 use std::borrow::Cow;
 
-pub fn generate(instance: &PackageInstance, out: LazyCreateBuilder) -> io::Result<()> {
-    let out = out.set_header("#!/bin/bash\n\nif [ \"$1\" = purge ];\nthen\n");
-    let mut out = out.finalize();
-    let mut triggers = Set::new();
-    if let Some(custom_script) = &instance.custom_postrm_script {
-        writeln!(out, "{}", custom_script.expand(instance.constants_by_variant()))?;
+fn write_db<W: io::Write>(mut out: W, instance: &PackageInstance) -> io::Result<()> {
+    let databases = instance.databases();
+    assert!(databases.len() < 2, "More than one database not supported yet");
+    if let Some((db_type, _db_config)) = databases.iter().next() {
+        writeln!(out)?;
+        writeln!(out, ". /usr/share/debconf/confmodule")?;
+        writeln!(out, ". /usr/share/dbconfig-common/dpkg/postrm.{}", db_type.lib_name())?;
+        writeln!(out, "dbc_go {} \"$@\"", instance.name)?;
+        writeln!(out)?;
     }
-    for (file_name, conf) in instance.config() {
-        if let ConfType::Dynamic { postprocess, .. } = &conf.conf_type {
-            let abs_file = format!("/etc/{}/{}", instance.config_sub_dir(), file_name.expand(instance.constants_by_variant()));
-            writeln!(out, "\trm -f {}", abs_file)?;
+    Ok(())
+}
 
-            triggers.insert(Cow::Owned(abs_file));
+pub fn generate(instance: &PackageInstance, out: LazyCreateBuilder) -> io::Result<()> {
+    let out = out.set_header("#!/bin/bash\n\n");
+    let mut out = out.finalize();
+    {
+        let mut out = LazyWriter::new(&mut out, b"\nif [ \"$1\" = purge ];\nthen\n", b"fi\n");
+        let mut triggers = Set::new();
+        if let Some(custom_script) = &instance.custom_postrm_script {
+            writeln!(out, "{}", custom_script.expand(instance.constants_by_variant()))?;
+        }
+        for (file_name, conf) in instance.config() {
+            if let ConfType::Dynamic { postprocess, .. } = &conf.conf_type {
+                let abs_file = format!("/etc/{}/{}", instance.config_sub_dir(), file_name.expand(instance.constants_by_variant()));
+                writeln!(out, "\trm -f {}", abs_file)?;
 
-            if let Some(postprocess) = postprocess {
-                for generated in &postprocess.generates {
-                    let (path, is_dir) = match &generated.ty {
-                        GeneratedType::File(path) => (path, false),
-                        GeneratedType::Dir(path) => (path, true),
-                    };
-                    let path = path.expand_to_cow(instance.constants_by_variant());
-                    let path = if path.starts_with('/') {
-                        path
-                    } else {
-                        Cow::<str>::Owned(format!("/etc/{}/{}", instance.config_sub_dir(), path))
-                    };
-                    if is_dir {
-                        writeln!(out, "\trm -rf {}", path)?;
-                    } else {
-                        writeln!(out, "\trm -f {}", path)?;
+                triggers.insert(Cow::Owned(abs_file));
+
+                if let Some(postprocess) = postprocess {
+                    for generated in &postprocess.generates {
+                        let (path, is_dir) = match &generated.ty {
+                            GeneratedType::File(path) => (path, false),
+                            GeneratedType::Dir(path) => (path, true),
+                        };
+                        let path = path.expand_to_cow(instance.constants_by_variant());
+                        let path = if path.starts_with('/') {
+                            path
+                        } else {
+                            Cow::<str>::Owned(format!("/etc/{}/{}", instance.config_sub_dir(), path))
+                        };
+                        if is_dir {
+                            writeln!(out, "\trm -rf {}", path)?;
+                        } else {
+                            writeln!(out, "\trm -f {}", path)?;
+                        }
+                        triggers.insert(path);
                     }
-                    triggers.insert(path);
                 }
             }
         }
-    }
 
-    let mut activated = Set::new();
+        let mut activated = Set::new();
 
-    for trigger in &triggers {
-        writeln!(out, "\tdpkg-trigger \"`realpath \"{}\"`\"", trigger)?;
-        if let Some(pos) = trigger.rfind('/') {
-            let parent = &trigger[..pos];
-            if parent != instance.config_sub_dir() && !triggers.contains(parent) && !activated.contains(parent) {
-                writeln!(out, "\tdpkg-trigger \"`realpath \"{}\"`\"", parent)?;
-                activated.insert(parent);
+        for trigger in &triggers {
+            writeln!(out, "\tdpkg-trigger \"`realpath \"{}\"`\"", trigger)?;
+            if let Some(pos) = trigger.rfind('/') {
+                let parent = &trigger[..pos];
+                if parent != instance.config_sub_dir() && !triggers.contains(parent) && !activated.contains(parent) {
+                    writeln!(out, "\tdpkg-trigger \"`realpath \"{}\"`\"", parent)?;
+                    activated.insert(parent);
+                }
             }
         }
+
+        writeln!(out, "\tdpkg-trigger \"{}-config-changed\"", instance.name)?;
+
+        out.finish()?;
     }
 
-    writeln!(out, "\tdpkg-trigger \"{}-config-changed\"", instance.name)?;
+    write_db(&mut out, instance)?;
 
     if let Some(out) = out.created() {
-        writeln!(out, "fi")?;
-        writeln!(out)?;
         writeln!(out, "#DEBHELPER#")?;
         writeln!(out)?;
         writeln!(out, "exit 0")?;

--- a/src/bin/generator/preinst.rs
+++ b/src/bin/generator/preinst.rs
@@ -1,5 +1,5 @@
 use std::io;
-use debcrafter::im_repr::PackageInstance;
+use debcrafter::im_repr::{PackageInstance, PackageOps};
 use crate::codegen::{LazyCreateBuilder};
 
 /*
@@ -23,6 +23,8 @@ fn write_patches<W: io::Write>(mut out: W, instance: &PackageInstance) -> io::Re
 pub fn generate(_instance: &PackageInstance, _out: LazyCreateBuilder) -> io::Result<()> {
     //let out = out.set_header("#!/bin/bash\n\nset -e\n\n");
     //let mut out = out.finalize();
+
+    // "use of dbc preinst hooks is now unnecesary and deprecated."
 
     // This is actually a bad idea because it could leave the dependency in a corrupt state
     // but maybe there's a reason to activate it in the future?

--- a/src/bin/generator/prerm.rs
+++ b/src/bin/generator/prerm.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::io::{self, Write};
 use std::borrow::Cow;
 use debcrafter::im_repr::{PackageInstance, PackageOps};
 use debcrafter::postinst::{CommandEnv, CommandPrivileges};
@@ -88,12 +88,16 @@ fn write_plug<W: io::Write>(mut out: W, instance: &PackageInstance) -> io::Resul
 }
 
 pub fn generate(instance: &PackageInstance, out: LazyCreateBuilder) -> io::Result<()> {
-    let out = out.set_header("#!/bin/bash\n\nset -e\n\n");
+    let out = out.set_header("#!/bin/bash\n\nset -e\n\n#DEBHELPER#\n\n");
     let mut out = out.finalize();
 
     write_plug(&mut out, instance)?;
     write_alternatives(&mut out, instance)?;
     write_patches(&mut out, instance)?;
+
+    if let Some(out) = out.created() {
+        writeln!(out, "exit 0")?;
+    }
 
     Ok(())
 }

--- a/src/error_report.rs
+++ b/src/error_report.rs
@@ -121,6 +121,11 @@ impl IntoDiagnostic for crate::im_repr::PackageError {
                     },
                 }
             },
+            PackageError::InvalidVersion(version, message) => {
+                Diagnostic::error()
+                    .with_message("invalid package version")
+                    .with_labels(vec![Label::primary(file_id, version).with_message(message)])
+            },
             PackageError::InvalidPackageName(error) => {
                 let mut invalid_chars = error.value.invalid_chars
                     .iter()

--- a/src/input.rs
+++ b/src/input.rs
@@ -268,6 +268,7 @@ pub(crate) struct DbConfig {
 
     pub(crate) template: String,
     pub(crate) min_version: String,
+    pub(crate) since: Spanned<String>,
     pub(crate) config_file_owner: String,
     pub(crate) config_file_group: String,
 }

--- a/src/postinst.rs
+++ b/src/postinst.rs
@@ -22,6 +22,7 @@ pub struct Config<'a> {
 pub struct CreateDbRequest<'a> {
     pub pkg_name: &'a str,
     pub db_type: &'a Database,
+    pub since: Option<&'a str>,
     pub config_path: &'a str,
     pub config_mode: &'a str,
     pub config_owner: &'a str,
@@ -537,6 +538,7 @@ pub fn handle_instance<T: HandlePostinst>(mut handler: T, instance: &PackageInst
         let request = CreateDbRequest {
             pkg_name: &instance.name,
             db_type,
+            since: db_config.since.as_deref(),
             config_path: &path,
             config_mode,
             config_owner: &config_owner,


### PR DESCRIPTION
Previously the dbconfig scripts were only called in config and postinst. This was wrong because it didn't give dbconfig a chance to handle databases properly. This commit fixes it by adding the missing scripts.